### PR TITLE
feat(wasmtime-cli): add async support flag

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3423,6 +3423,7 @@ dependencies = [
  "criterion",
  "env_logger 0.10.0",
  "filecheck",
+ "futures",
  "humantime 2.1.0",
  "libc",
  "listenfd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ wasmtime-wasi-http = { workspace = true, optional = true }
 wasmtime-runtime = { workspace = true }
 clap = { workspace = true, features = ["color", "suggestions", "derive"] }
 anyhow = { workspace = true }
+futures = { workspace = true }
 target-lexicon = { workspace = true }
 humantime = "2.0.0"
 once_cell = { workspace = true }
@@ -51,14 +52,24 @@ rustix = { workspace = true, features = ["mm", "param"] }
 
 [dev-dependencies]
 # depend again on wasmtime to activate its default features for tests
-wasmtime = { workspace = true, features = ['component-model', 'async', 'default', 'winch'] }
+wasmtime = { workspace = true, features = [
+  'component-model',
+  'async',
+  'default',
+  'winch',
+] }
 env_logger = { workspace = true }
 log = { workspace = true }
 filecheck = { workspace = true }
 tempfile = { workspace = true }
 test-programs = { path = "crates/test-programs" }
 wasmtime-runtime = { workspace = true }
-tokio = { version = "1.8.0", features = ["rt", "time", "macros", "rt-multi-thread"] }
+tokio = { version = "1.8.0", features = [
+  "rt",
+  "time",
+  "macros",
+  "rt-multi-thread",
+] }
 wast = { workspace = true }
 criterion = "0.5.0"
 num_cpus = "1.13.0"
@@ -187,7 +198,9 @@ byte-array-literals = { path = "crates/wasi-preview1-component-adapter/byte-arra
 regalloc2 = "0.9.2"
 
 # cap-std family:
-target-lexicon = { version = "0.12.3", default-features = false, features = ["std"] }
+target-lexicon = { version = "0.12.3", default-features = false, features = [
+  "std",
+] }
 cap-std = "2.0.0"
 cap-rand = { version = "2.0.0", features = ["small_rng"] }
 cap-fs-ext = "2.0.0"
@@ -215,8 +228,15 @@ wit-component = "0.13.2"
 
 # Non-Bytecode Alliance maintained dependencies:
 # --------------------------
-object = { version = "0.31.1", default-features = false, features = ['read_core', 'elf', 'std'] }
-gimli = { version = "0.27.0", default-features = false, features = ['read', 'std'] }
+object = { version = "0.31.1", default-features = false, features = [
+  'read_core',
+  'elf',
+  'std',
+] }
+gimli = { version = "0.27.0", default-features = false, features = [
+  'read',
+  'std',
+] }
 anyhow = "1.0.22"
 windows-sys = "0.48.0"
 env_logger = "0.10"
@@ -255,6 +275,7 @@ default = [
   "jitdump",
   "wasmtime/wat",
   "wasmtime/parallel-compilation",
+  "wasmtime/async",
   "vtune",
   "wasi-nn",
   "wasi-threads",
@@ -266,12 +287,15 @@ vtune = ["wasmtime/vtune"]
 wasi-nn = ["dep:wasmtime-wasi-nn"]
 wasi-threads = ["dep:wasmtime-wasi-threads"]
 wasi-http = ["dep:wasmtime-wasi-http"]
-pooling-allocator = ["wasmtime/pooling-allocator", "wasmtime-cli-flags/pooling-allocator"]
+pooling-allocator = [
+  "wasmtime/pooling-allocator",
+  "wasmtime-cli-flags/pooling-allocator",
+]
 all-arch = ["wasmtime/all-arch"]
 component-model = [
   "wasmtime/component-model",
   "wasmtime-wast/component-model",
-  "wasmtime-cli-flags/component-model"
+  "wasmtime-cli-flags/component-model",
 ]
 winch = ["wasmtime/winch"]
 wmemcheck = ["wasmtime/wmemcheck"]

--- a/tests/all/cli_tests.rs
+++ b/tests/all/cli_tests.rs
@@ -731,12 +731,34 @@ fn wasi_misaligned_pointer() -> Result<()> {
 }
 
 #[test]
+fn hello_with_async() -> Result<()> {
+    let wasm = build_wasm("tests/all/cli_tests/hello_wasi_snapshot1.wat")?;
+    let stdout = run_wasmtime(&["--disable-cache", "--async", wasm.path().to_str().unwrap()])?;
+    assert_eq!(stdout, "Hello, world!\n");
+    Ok(())
+}
+
+#[test]
 #[ignore] // FIXME(#6811) currently is flaky and may produce no output
 fn hello_with_preview2() -> Result<()> {
     let wasm = build_wasm("tests/all/cli_tests/hello_wasi_snapshot1.wat")?;
     let stdout = run_wasmtime(&[
         "--disable-cache",
         "--preview2",
+        wasm.path().to_str().unwrap(),
+    ])?;
+    assert_eq!(stdout, "Hello, world!\n");
+    Ok(())
+}
+
+#[test]
+#[ignore] // FIXME(#6811) currently is flaky and may produce no output
+fn hello_with_preview2_and_async() -> Result<()> {
+    let wasm = build_wasm("tests/all/cli_tests/hello_wasi_snapshot1.wat")?;
+    let stdout = run_wasmtime(&[
+        "--disable-cache",
+        "--preview2",
+        "--async",
         wasm.path().to_str().unwrap(),
     ])?;
     assert_eq!(stdout, "Hello, world!\n");
@@ -805,6 +827,19 @@ fn run_basic_component() -> Result<()> {
     ])?;
     run_wasmtime(&["--disable-cache", "--wasm-features=component-model", path])?;
 
+    Ok(())
+}
+
+#[test]
+#[cfg_attr(not(feature = "component-model"), ignore)]
+fn run_basic_component_async() -> Result<()> {
+    let wasm = build_wasm("tests/all/cli_tests/component-basic.wat")?;
+    run_wasmtime(&[
+        "--disable-cache",
+        "--wasm-features=component-model",
+        "--async",
+        wasm.path().to_str().unwrap(),
+    ])?;
     Ok(())
 }
 


### PR DESCRIPTION
This will add a flag called `--async` that will inject the asynchronous functions to linkers instead of the synchronous one.
